### PR TITLE
Make this more convenient to run

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.sh]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh	text=auto
+*.sh	text eol=lf

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu-16.04-amd64"
-
+  config.vm.box = "bento/ubuntu-16.04"
+  
   config.vm.hostname = "gitlab.example.com"
 
   config.vm.network "private_network", ip: "192.168.33.20"


### PR DESCRIPTION
In order to run this on my 1709 Win10 machine I had to make the following changes:

- The shell scripts failed with the #!/bin/bash^M not found error, because git switched the line endings to CRLF as it would on any Windows machine without being configured.

- The vagrantfile was looking for a custom box locally which is not guaranteed to exist on everyone's machine.  I therefore switched to a "well-known" box from the vagrant cloud that matches the latest gitlab platform requirements.

Thanks @rgl for the effort to make these vagrant environments and I hope this PR helps making it more accessible and easier to use out-of-the-box.

Best regards,

Ruben