### PR TITLE
Point to the base box on Vagrant Cloud + updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Email notifications are sent to a local [MailHog](https://github.com/mailhog/Mai
 
 # Usage
 
-Install the [Ubuntu Base Box](https://github.com/rgl/ubuntu-vagrant).
-
 Start the environment:
 
     vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 gitlab_version = '12.7.5-ce.0' # NB execute apt-cache madison gitlab-ce to known the available versions.
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu-18.04-amd64"
+  config.vm.box = "rgl/ubuntu-1804-amd64"
 
   config.vm.hostname = "gitlab.example.com"
 


### PR DESCRIPTION
If you point to the published box on Vagrant Cloud, it is no longer needed to create/build the base box locally. With a correct pointer to the base box, the "Install base box" is obsolete. This gives a better user experience to use this setup.

BTW, thanks for your work on this. This helps me in testing [my pull request for the Terraform Gitlab Provider](https://github.com/terraform-providers/terraform-provider-gitlab/pull/247) locally as Gitlab in a container doesn't run correctly for me due to [this errror](https://gitlab.com/gitlab-org/omnibus-gitlab/issues/4342).